### PR TITLE
Add global leaderboard with user score tracking

### DIFF
--- a/client/contexts/AuthContext.tsx
+++ b/client/contexts/AuthContext.tsx
@@ -85,6 +85,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
               username: profile.username,
               email: profile.email,
               createdAt: serverTimestamp(),
+              totalScore: 0,
+              gamesPlayed: 0,
             },
             { merge: true },
           );
@@ -170,6 +172,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
             username: username.trim(),
             email: email.trim(),
             createdAt: serverTimestamp(),
+            totalScore: 0,
+            gamesPlayed: 0,
           },
           { merge: true },
         );

--- a/client/contexts/AuthContext.tsx
+++ b/client/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
   signInWithEmailAndPassword,
   signOut,
   updateProfile,
+  signInAnonymously,
 } from "firebase/auth";
 import { db } from "@/lib/firebase";
 import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore";
@@ -59,8 +60,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       }
       const ref = doc(db, "users", fbUser.uid);
       let profile: { username: string; email: string; createdAt?: any } = {
-        username: fbUser.displayName || fbUser.email?.split("@")[0] || "Player",
-        email: fbUser.email || "",
+        username:
+          fbUser.displayName ||
+          fbUser.email?.split("@")[0] ||
+          (fbUser.isAnonymous ? "Guest" : "Player"),
+        email: fbUser.email || (fbUser.isAnonymous ? "" : ""),
         createdAt: new Date().toISOString(),
       };
       try {
@@ -111,6 +115,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       clearTimeout(t);
       unsub();
     };
+  }, []);
+
+  // Auto sign-in anonymously to allow storing scores for guests
+  useEffect(() => {
+    if (!auth.currentUser) {
+      signInAnonymously(auth).catch(() => {});
+    }
   }, []);
 
   const register = async (

--- a/client/pages/Leaderboard.tsx
+++ b/client/pages/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Card,
   CardContent,

--- a/client/pages/Leaderboard.tsx
+++ b/client/pages/Leaderboard.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 import { db } from "@/lib/firebase";
 import {
   collectionGroup,
+  collection,
   getDocs,
   limit,
   orderBy,
@@ -148,6 +149,38 @@ function useLeaderboard(gameId: GameId) {
   return rows;
 }
 
+function useGlobalLeaderboard() {
+  const { authState } = useAuth();
+  const [rows, setRows] = useState<LeaderboardEntry[]>([]);
+  useEffect(() => {
+    async function run() {
+      try {
+        const users = collection(db, "users");
+        const q = query(users, orderBy("totalScore", "desc"), limit(20));
+        const snap = await getDocs(q);
+        const result: LeaderboardEntry[] = [];
+        let i = 0;
+        snap.forEach((d) => {
+          const data = d.data() as any;
+          const name = data.username || data.email?.split("@")[0] || "Player";
+          result.push({
+            rank: ++i,
+            name,
+            score: data.totalScore || 0,
+            avatar: name.slice(0, 1).toUpperCase(),
+            isCurrentUser: !!authState.user && d.id === authState.user.id,
+          });
+        });
+        setRows(result);
+      } catch (e) {
+        setRows([]);
+      }
+    }
+    run();
+  }, [authState.user?.id]);
+  return rows;
+}
+
 export default function Leaderboard() {
   const [timeFilter, setTimeFilter] = useState("all-time");
 
@@ -265,6 +298,7 @@ export default function Leaderboard() {
     </div>
   );
 
+  const overallRows = useGlobalLeaderboard();
   const cfRows = useLeaderboard("card-flip");
   const gcRows = useLeaderboard("guess-cup");
   const ssRows = useLeaderboard("simon-says");
@@ -294,8 +328,12 @@ export default function Leaderboard() {
           ))}
         </div>
 
-        <Tabs defaultValue="card-flip" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-4">
+        <Tabs defaultValue="overall" className="space-y-6">
+          <TabsList className="grid w-full grid-cols-5">
+            <TabsTrigger value="overall" className="gap-2">
+              <Trophy className="h-4 w-4" />
+              Overall
+            </TabsTrigger>
             <TabsTrigger value="card-flip" className="gap-2">
               <Layers className="h-4 w-4" />
               Card Flip
@@ -313,6 +351,21 @@ export default function Leaderboard() {
               Achievements
             </TabsTrigger>
           </TabsList>
+
+          <TabsContent value="overall" className="space-y-4">
+            <Card className="bg-card/50">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Trophy className="h-5 w-5 text-primary" />
+                  Overall - Top Players
+                </CardTitle>
+                <CardDescription>Total score across all games</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <LeaderboardTable data={overallRows} />
+              </CardContent>
+            </Card>
+          </TabsContent>
 
           <TabsContent value="card-flip" className="space-y-4">
             <Card className="bg-card/50">


### PR DESCRIPTION
## Purpose

The user wanted to fix the leaderboard functionality to show real results based on user performance. They specifically requested that each user/player be associated with a score that accumulates when they play games, and that this total score be displayed on a leaderboard. The user also needed guidance on Firebase configuration changes to support score storage.

## Code changes

- **Added score tracking**: Modified `AuthContext.tsx` to initialize new users with `totalScore: 0` and `gamesPlayed: 0` fields
- **Implemented anonymous authentication**: Added automatic anonymous sign-in to allow guest users to accumulate scores
- **Enhanced user stats system**: Updated `user-stats.ts` to maintain aggregate totals on the main user document, tracking both total score and games played across all games
- **Created global leaderboard**: Added new `useGlobalLeaderboard` hook in `Leaderboard.tsx` that queries users by total score
- **Updated leaderboard UI**: Added "Overall" tab to display top players ranked by cumulative score across all games
- **Improved user handling**: Enhanced username generation for anonymous users (displays as "Guest")

The changes ensure that user scores are properly stored in Firestore and displayed on a comprehensive leaderboard that ranks players by their total accumulated score.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c1804a2c98b1444982e06ca9045213cc/pulse-haven)

👀 [Preview Link](https://c1804a2c98b1444982e06ca9045213cc-pulse-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c1804a2c98b1444982e06ca9045213cc</projectId>-->
<!--<branchName>pulse-haven</branchName>-->